### PR TITLE
set-AL_DOWNLOAD_DEPENDENCIES=OFF-when-AL_DEVELOPMENT_LAYOUT=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,12 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/common/cmake/ALLocalPaths.cmake)
 # Configuration options for common assets
 ################################################################################
 option( AL_DOWNLOAD_DEPENDENCIES "Automatically download assets from the AL git repository" ON )
+option( AL_DEVELOPMENT_LAYOUT "Use development repositories from sibling directory" OFF )
+if( AL_DEVELOPMENT_LAYOUT AND AL_DOWNLOAD_DEPENDENCIES )
+    message( STATUS "AL_DEVELOPMENT_LAYOUT=ON: setting AL_DOWNLOAD_DEPENDENCIES=OFF" )
+    set( AL_DOWNLOAD_DEPENDENCIES OFF CACHE BOOL "Automatically download assets from the AL git
+    repository" FORCE )
+endif()
 set( AL_CORE_GIT_REPOSITORY "https://github.com/iterorganization/IMAS-Core.git" CACHE STRING "Git repository of AL-core" )
 set( AL_CORE_VERSION "main" CACHE STRING "Git commit/tag/branch of AL-core" )
 

--- a/doc/doc_common/dev_guide.rst
+++ b/doc/doc_common/dev_guide.rst
@@ -45,10 +45,14 @@ folder is not important).
     └── data-dictionary/
 
 Then, when you configure a project for building (see the Configuration section in the
-building and installation documentation), set the
-option ``-D AL_DOWNLOAD_DEPENDENCIES=OFF``. Instead of fetching requirements from the
-ITER git, CMake will now use the repositories as they are checked out in your
-development folders.
+building and installation documentation), set the option
+``-D AL_DEVELOPMENT_LAYOUT=ON``. Instead of fetching requirements from the GitHub repositories,
+CMake will now use the repositories as they are checked out in your development
+folders. This option automatically disables ``AL_DOWNLOAD_DEPENDENCIES``.
+
+    When both ``AL_DEVELOPMENT_LAYOUT=OFF`` and ``AL_DOWNLOAD_DEPENDENCIES=OFF`` are
+    used, CMake expects dependencies such as ``al-core`` to be available as installed
+    packages through ``pkg-config``.
 
     With this setup, it is your responsibility to update the repositories to their
     latest versions (if needed). The ``<component>_VERSION`` configuration options are


### PR DESCRIPTION

As we have development layout ON it make s no sense to have AL_DOWNLOAD_DEPENDENCIES=ON.
Fored AL_DOWNLOAD_DEPENDENCIES to OFF when AL_DEVELOPMENT_LAYOUT=ON
```bash
$ cmake -B build -D AL_DEVELOPMENT_LAYOUT=ON
-- AL_DEVELOPMENT_LAYOUT=ON: setting AL_DOWNLOAD_DEPENDENCIES=OFF
-- Found Git: /usr/bin/git (found version "2.39.3")
-- The C compiler identification is GNU 13.2.0
-- The CXX compiler identification is GNU 13.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /work/imas/opt/EasyBuild/software/GCCcore/13.2.0/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /work/imas/opt/EasyBuild/software/GCCcore/13.2.0/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
Building a development version of the Access Layer core
-- Found Boost: /work/imas/opt/EasyBuild/software/Boost/1.83.0-GCC-13.2.0/lib64/cmake/Boost-1.83.0/BoostConfig.cmake (found version "1.83.0") found components: filesystem
-- Found HDF5: /work/imas/opt/EasyBuild/software/HDF5/1.14.3-gompi-2023b/lib/libhdf5.so;/usr/lib64/libpthread.a;/work/imas/opt/EasyBuild/software/Szip/2.1.1-GCCcore-13.2.0/lib/libsz.so;/work/imas/opt/EasyBuild/software/zlib/1.2.13-GCCcore-13.2.0/lib/libz.so;/usr/lib64/libdl.a;/usr/lib64/libm.so;/usr/lib64/libm.so;/usr/lib64/libpthread.a (found version "1.14.3") found components: C HL
-- The Fortran compiler identification is GNU 13.2.0
-- Detecting Fortran compiler ABI info
-- Detecting Fortran compiler ABI info - done
-- Check for working Fortran compiler: /work/imas/opt/EasyBuild/software/GCCcore/13.2.0/bin/gfortran - skipped
Building a development version of the Access Layer Fortran HLI
-- Found Python3: /work/imas/opt/EasyBuild/software/Python/3.11.5-GCCcore-13.2.0/bin/python3.11 (found version "3.11.5") found components: Interpreter
-- Found Python: /work/imas/opt/EasyBuild/software/Python/3.11.5-GCCcore-13.2.0/bin/python3.11
-- Configuring done (19.7s)
-- Generating done (2.0s)
-- Build files have been written to: /home/ITER/sawantp1/github/IMAS-Fortran/build
```